### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/product_informations_controller.rb
+++ b/app/controllers/product_informations_controller.rb
@@ -24,7 +24,19 @@ class ProductInformationsController < ApplicationController
     @product_information = ProductInformation.find(params[:id])
   end
 
-
+  def edit
+    @product_information = ProductInformation.find(params[:id])
+    # redirect_to root_path unless current_user == @product_information.user
+  end
+  
+  def update
+    @product_information = ProductInformation.find(params[:id])
+    if @product_information.update(product_information_params)
+      redirect_to product_information_path(@product_information)
+    else
+      render :edit
+    end
+  end
 
 
 

--- a/app/controllers/product_informations_controller.rb
+++ b/app/controllers/product_informations_controller.rb
@@ -26,8 +26,7 @@ class ProductInformationsController < ApplicationController
 
   def edit
     @product_information = ProductInformation.find(params[:id])
-    # redirect_to root_path unless current_user == @product_information.user
-  end
+   end
   
   def update
     @product_information = ProductInformation.find(params[:id])

--- a/app/controllers/product_informations_controller.rb
+++ b/app/controllers/product_informations_controller.rb
@@ -1,5 +1,6 @@
 class ProductInformationsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:index, :show,]
+
 
   
   
@@ -26,6 +27,9 @@ class ProductInformationsController < ApplicationController
 
   def edit
     @product_information = ProductInformation.find(params[:id])
+    unless current_user == @product_information.user
+      redirect_to root_path
+    end
    end
   
   def update

--- a/app/controllers/product_informations_controller.rb
+++ b/app/controllers/product_informations_controller.rb
@@ -1,5 +1,6 @@
 class ProductInformationsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show,]
+  before_action :set_tweet, only: [:show, :edit, :update]
 
 
   
@@ -22,18 +23,15 @@ class ProductInformationsController < ApplicationController
   end
 
   def show
-    @product_information = ProductInformation.find(params[:id])
   end
 
   def edit
-    @product_information = ProductInformation.find(params[:id])
     unless current_user == @product_information.user
       redirect_to root_path
     end
    end
   
   def update
-    @product_information = ProductInformation.find(params[:id])
     if @product_information.update(product_information_params)
       redirect_to product_information_path(@product_information)
     else
@@ -50,6 +48,10 @@ class ProductInformationsController < ApplicationController
 
   def product_information_params
    params.require(:product_information).permit(:image, :name, :description, :category_id, :situation_id, :load_id, :area_id, :period_id, :price ).merge(user_id: current_user.id)
+  end
+
+  def set_tweet
+    @product_information = ProductInformation.find(params[:id])
   end
 
   

--- a/app/views/product_informations/edit.html.erb
+++ b/app/views/product_informations/edit.html.erb
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', product_information_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/product_informations/edit.html.erb
+++ b/app/views/product_informations/edit.html.erb
@@ -10,7 +10,7 @@ app/assets/stylesheets/items/new.css %>
     <%= form_with model: @product_information, local: true do |f| %>
 
     
-    <% render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     
 
     <%# 商品画像 %>

--- a/app/views/product_informations/edit.html.erb
+++ b/app/views/product_informations/edit.html.erb
@@ -9,9 +9,9 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @product_information, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    
+    <% render 'shared/error_messages', model: f.object %>
+    
 
     <%# 商品画像 %>
     <div class="img-upload">

--- a/app/views/product_informations/edit.html.erb
+++ b/app/views/product_informations/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @product_information, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:situation_id, Situation.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:load_id, Load.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:area_id, Area.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:period_id, Period.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/product_informations/show.html.erb
+++ b/app/views/product_informations/show.html.erb
@@ -25,7 +25,7 @@
 
    <% if user_signed_in? %>
     <% if current_user.id == @product_information.user_id %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_product_information_path, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     


### PR DESCRIPTION
WHAT
商品情報編集機能の実装。
WHY
出品した商品の情報を後から変更できるようにするため。

↓ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/7a668d66e64e604bfdc136cb90708c52

↓必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/53d95532a19289e996d15c04b54243e7

↓入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
 https://gyazo.com/ac79ef4910ea156bd9da981960d19a09

↓何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/11997e5be5e570c9055026ca91cc6a98

  ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
 https://gyazo.com/2bad1e3d546084b9991fa3ca39a5f3fd

↓ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/2783123229805350b279dae3693f5aaf

↓ 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/c9547a4c32e96536781493191365ab4f



